### PR TITLE
Change fold invocation order.

### DIFF
--- a/src/fold_ppx/fold_ppx.ml
+++ b/src/fold_ppx/fold_ppx.ml
@@ -73,11 +73,6 @@ let kind_to_types = function
 
 type l = L : 'a layout -> l
 
-let parse_layout_str ~loc = function
-  | "fortran" -> L Fortran_layout
-  | "c"       -> L C_layout
-  | ls        -> location_error ~loc "Unrecognized layout: %s" ls
-
 let to_fold_params = function
   | L Fortran_layout -> "fortran_layout", 1, false
   | L C_layout       -> "c_layout", 0, true
@@ -144,9 +139,11 @@ let length_expr ~minus_one arr =
   else
     Exp.apply (ex_id "Array1.dim") [Nolabel, (ex_id arr)]
 
-type 'a  operation =
-  | Iter of 'a * 'a               (* f and v *)
-  | Fold of (bool * 'a * 'a * 'a) (* upto, f, init, v*)
+type e = Parsetree.expression
+
+type operation =
+  | Iter of e * e               (* f and v *)
+  | Fold of (bool * e * e * e)  (* upto, f, init, v*)
 
 let fold_apply_f ~upto fun_exp ~ref ~arr ~index =
   if upto then
@@ -202,69 +199,63 @@ let create op kind =
               (Exp.apply (ex_id name_c) [Nolabel, (ex_id "b")])])))
     (Exp.apply (ex_id name) [Nolabel, v])
 
-let parse_payload_fold loc ba_type d = function
-  | [{ pstr_desc = Pstr_eval
-        ({pexp_desc = Pexp_apply
-              (fun_exp, [(Nolabel, init); (Nolabel, v);(_,_w)]); _}, _); _ }] ->
-      location_error ~loc "Too many %s argument to fold" ba_type
-  | [{ pstr_desc = Pstr_eval
-        ({pexp_desc = Pexp_apply
-              (fun_exp, [(Nolabel, init); (Nolabel, v)]); _}, _); _ }] ->
-      Fold (d, fun_exp, init, v)
-  | [{ pstr_desc = Pstr_eval
-        ({pexp_desc = Pexp_apply
-              (fun_exp, [(Nolabel, init); ]); _}, _); _ }] ->
-      location_error ~loc "Missing %s argument to fold" ba_type
-  | [{ pstr_desc = Pstr_eval
-        ({pexp_desc = _}, _); _}] ->
-      location_error ~loc "Missing init and %s argument to fold" ba_type
-  | _ ->
-      location_error ~loc "Missing fold arguments"
+let to_fs = function | true -> "fold_left" | false -> "fold_right"
 
-let parse_payload_iter loc ba_type = function
-  | [{ pstr_desc = Pstr_eval
-        ({pexp_desc = Pexp_apply
-              (fun_exp, [(Nolabel, v);(_,_w)]); _}, _); _ }] ->
-      location_error ~loc "Too many %s argument to iter" ba_type
-  | [{ pstr_desc = Pstr_eval
-        ({pexp_desc = Pexp_apply
-              (fun_exp, [(Nolabel, v)]); _}, _); _ }] ->
-    Iter (fun_exp, v)
-  | [{ pstr_desc = Pstr_eval
-        ({pexp_desc = _}, _); _}] ->
-      location_error ~loc "Missing init and %s argument to iter" ba_type
+let parse_fold_args loc d = function
+  | [ (Nolabel, fun_exp)
+    ; (Nolabel, init_exp)
+    ; (Nolabel, array_exp)
+    ] -> Fold (d, fun_exp, init_exp, array_exp)
+  | [] | [_] | [_;_] ->
+      location_error ~loc "Missing %s arguments" (to_fs d)
   | _ ->
+      location_error ~loc "Too many arguments to %s" (to_fs d)
+
+let parse_iter_args loc = function
+  | [ (Nolabel, fun_exp)
+    ; (Nolabel, array_exp)
+    ] -> Iter (fun_exp, array_exp)
+  | [] | [_]  ->
       location_error ~loc "Missing iter arguments"
+  | _ ->
+      location_error ~loc "Too many argument to iter"
 
-let parse_payload loc ba_type payload = function
-  | Iter ((), ())        -> parse_payload_iter loc ba_type payload
-  | Fold (d, (), (), ()) -> parse_payload_fold loc ba_type d payload
+let parse_payload ~loc = function
+  | [{pstr_desc =
+        Pstr_eval
+          ({pexp_desc =
+              Pexp_apply ({pexp_desc =
+                Pexp_ident {txt = Longident.Lident f}}, args)}, _)}] ->
+      begin match f with
+        | "fold_left"  -> parse_fold_args loc true args
+        | "fold_right" -> parse_fold_args loc false args
+        | "iter"       -> parse_iter_args loc args
+        | operation    -> location_error ~loc "Unrecognized command: %s" operation
+      end
+  | [] -> location_error ~loc "Missing fold_left, fold_right or iter invocation."
+  | _  -> location_error ~loc "Incorrect fold_left, fold_right or iter invocation."
 
-let parse_operation ~loc = function
-  | "iter"       -> Iter ((),())
-  | "fold_left"  -> Fold (true,(),(),())
-  | "fold_right" -> Fold (false,(),(),())
-  | operation    -> location_error ~loc "Unrecognized command: %s" operation
+let parse_layout ~loc = function
+  | None            -> None
+  | Some "fortran"  -> Some (L Fortran_layout)
+  | Some "c"        -> Some (L C_layout)
+  | Some ls         -> location_error ~loc "Unrecognized layout: %s" ls
 
-let parse ?layout loc operation ks payload =
+let parse ?layout loc ~kind payload =
   try
-    let op   = parse_operation ~loc operation in
-    let kind = parse_kind ~loc ks in
-    match layout with
-    | None ->
-      let ope = parse_payload loc "array1" payload op in
-      create ope kind
-    | Some ls ->
-      let layout = parse_layout_str ~loc ls in
-      let ope = parse_payload loc "array1" payload op in
-      create_layout_specific ope kind layout
+    let kind   = parse_kind ~loc kind in
+    let op     = parse_payload ~loc payload in
+    match parse_layout ~loc layout with
+    | None   -> create op kind
+    | Some l -> create_layout_specific op kind l
   with Location.Error e ->
     Exp.extension ~loc (extension_of_error e)
 
+
 let transform loc txt payload def =
   match split '.' txt with
-  | ["array1"; oper; kind]         -> parse loc oper kind payload
-  | ["array1"; oper; kind; layout] -> parse ~layout loc oper kind payload
+  | ["array1"; kind]         -> parse loc ~kind payload
+  | ["array1"; kind; layout] -> parse ~layout loc ~kind payload
   | _ -> def ()
 
 let bigarray_fold_mapper _argv =

--- a/src/scripts/fold_ppx_prof.ml
+++ b/src/scripts/fold_ppx_prof.ml
@@ -20,8 +20,8 @@ let sum_r v =
     r := !r +. Array1.unsafe_get v i
   done;
   !r
-let sum_f v = [%array1.fold_left.float64.fortran (+.) 0. v]
-let sum_l v = [%array1.fold_left.float64 (+.) 0. v]
+let sum_f v = [%array1.float64.fortran fold_left (+.) 0. v]
+let sum_l v = [%array1.float64 fold_left (+.) 0. v]
 
 let () =
   let samples, n =

--- a/src/scripts/fold_ppx_prof.ml
+++ b/src/scripts/fold_ppx_prof.ml
@@ -21,7 +21,9 @@ let sum_r v =
   done;
   !r
 let sum_f v = [%array1.float64.fortran fold_left (+.) 0. v]
+let sum_fl v = [%array1.float64.fortran fold_left ~init:0. ~f:(+.) v]
 let sum_l v = [%array1.float64 fold_left (+.) 0. v]
+let sum_ll v = [%array1.float64 fold_left ~init:0. ~f:(+.) v]
 
 let () =
   let samples, n =
@@ -37,6 +39,8 @@ let () =
   let native  = test "native" (fun (n,_,_) -> sum_n n) in
   let regular = test "regular fold" (fun (_,f,_) -> sum_r f) in
   let typed   = test "created fold_ppx" (fun (_,f,_) -> sum_f f) in
+  let _       = test "created fold_ppx labeled" (fun (_,f,_) -> sum_fl f) in
   let wlayout = test "no layout" (fun (_,f,_) -> sum_l f) in
+  let _       = test "no layout labeled" (fun (_,f,_) -> sum_l f) in
   Printf.printf "equal %b\n"
     (native = regular && regular = typed && typed = wlayout)

--- a/src/scripts/fold_ppx_test.ml
+++ b/src/scripts/fold_ppx_test.ml
@@ -14,9 +14,9 @@ let generate kind n =
   native, f, c
 
 let sum_n (v : float array) = Array.fold_left (+.) 0. v
-let sum_b v = [%array1.fold_left.float64 (+.) 0. v]
-let sum_b_f v = [%array1.fold_left.float64.fortran (+.) 0. v]
-let sum_b_c v = [%array1.fold_left.float64.c (+.) 0. v]
+let sum_b v = [%array1.float64 fold_left (+.) 0. v]
+let sum_b_f v = [%array1.float64.fortran fold_left (+.) 0. v]
+let sum_b_c v = [%array1.float64.c fold_left (+.) 0. v]
 
 (* TODO: Get to the bottom of if the differences are
    just due to comparing left vs right and different roundings.*)
@@ -75,118 +75,118 @@ let () =
   per "float32"
     { sum_n = (fun (v : float array) -> Array.fold_left (+.) 0. v)
     ; kind  = Float32
-    ; sum_fl = (fun v -> [%array1.fold_left.float32.fortran (+.) 0. v])
-    ; sum_fr = (fun v -> [%array1.fold_right.float32.fortran (+.) 0. v])
-    ; sum_cl = (fun v -> [%array1.fold_left.float32.c (+.) 0. v])
-    ; sum_cr = (fun v -> [%array1.fold_right.float32.c (+.) 0. v])
+    ; sum_fl = (fun v -> [%array1.float32.fortran fold_left (+.) 0. v])
+    ; sum_fr = (fun v -> [%array1.float32.fortran fold_right (+.) 0. v])
+    ; sum_cl = (fun v -> [%array1.float32.c fold_left (+.) 0. v])
+    ; sum_cr = (fun v -> [%array1.float32.c fold_right (+.) 0. v])
     ; eq = eq_array
     };
   per "float64"
     { sum_n = (fun (v : float array) -> Array.fold_left (+.) 0. v)
     ; kind  = Float64
-    ; sum_fl = (fun v -> [%array1.fold_left.float64.fortran (+.) 0. v])
-    ; sum_fr = (fun v -> [%array1.fold_right.float64.fortran (+.) 0. v])
-    ; sum_cl = (fun v -> [%array1.fold_left.float64.c (+.) 0. v])
-    ; sum_cr = (fun v -> [%array1.fold_right.float64.c (+.) 0. v])
+    ; sum_fl = (fun v -> [%array1.float64.fortran fold_left (+.) 0. v])
+    ; sum_fr = (fun v -> [%array1.float64.fortran fold_right (+.) 0. v])
+    ; sum_cl = (fun v -> [%array1.float64.c fold_left (+.) 0. v])
+    ; sum_cr = (fun v -> [%array1.float64.c fold_right (+.) 0. v])
     ; eq = eq_array
     };
   per "complex32"
     { sum_n = (fun v  -> Array.fold_left Complex.add Complex.zero v)
     ; kind  = Complex32
-    ; sum_fl = (fun v -> [%array1.fold_left.complex32.fortran Complex.add Complex.zero v])
-    ; sum_fr = (fun v -> [%array1.fold_right.complex32.fortran Complex.add Complex.zero v])
-    ; sum_cl = (fun v -> [%array1.fold_left.complex32.c Complex.add Complex.zero v])
-    ; sum_cr = (fun v -> [%array1.fold_right.complex32.c Complex.add Complex.zero v])
+    ; sum_fl = (fun v -> [%array1.complex32.fortran fold_left Complex.add Complex.zero v])
+    ; sum_fr = (fun v -> [%array1.complex32.fortran fold_right Complex.add Complex.zero v])
+    ; sum_cl = (fun v -> [%array1.complex32.c fold_left Complex.add Complex.zero v])
+    ; sum_cr = (fun v -> [%array1.complex32.c fold_right Complex.add Complex.zero v])
     ; eq = eq_array_c
     };
   per "complex64"
     { sum_n = (fun v  -> Array.fold_left Complex.add Complex.zero v)
     ; kind  = Complex64
-    ; sum_fl = (fun v -> [%array1.fold_left.complex64.fortran Complex.add Complex.zero v])
-    ; sum_fr = (fun v -> [%array1.fold_right.complex64.fortran Complex.add Complex.zero v])
-    ; sum_cl = (fun v -> [%array1.fold_left.complex64.c Complex.add Complex.zero v])
-    ; sum_cr = (fun v -> [%array1.fold_right.complex64.c Complex.add Complex.zero v])
+    ; sum_fl = (fun v -> [%array1.complex64.fortran fold_left Complex.add Complex.zero v])
+    ; sum_fr = (fun v -> [%array1.complex64.fortran fold_right Complex.add Complex.zero v])
+    ; sum_cl = (fun v -> [%array1.complex64.c fold_left Complex.add Complex.zero v])
+    ; sum_cr = (fun v -> [%array1.complex64.c fold_right Complex.add Complex.zero v])
     ; eq = eq_array_c
     };
   per "int8_signed"
     { sum_n = (fun (v : int array) -> Array.fold_left (+) 0 v)
     ; kind  = Int8_signed
-    ; sum_fl = (fun v -> [%array1.fold_left.int8_signed.fortran (+) 0 v])
-    ; sum_fr = (fun v -> [%array1.fold_right.int8_signed.fortran (+) 0 v])
-    ; sum_cl = (fun v -> [%array1.fold_left.int8_signed.c (+) 0 v])
-    ; sum_cr = (fun v -> [%array1.fold_right.int8_signed.c (+) 0 v])
+    ; sum_fl = (fun v -> [%array1.int8_signed.fortran fold_left (+) 0 v])
+    ; sum_fr = (fun v -> [%array1.int8_signed.fortran fold_right (+) 0 v])
+    ; sum_cl = (fun v -> [%array1.int8_signed.c fold_left (+) 0 v])
+    ; sum_cr = (fun v -> [%array1.int8_signed.c fold_right (+) 0 v])
     ; eq = (=)
     };
   per "int8_unsigned"
     { sum_n = (fun (v : int array) -> Array.fold_left (+) 0 v)
     ; kind  = Int8_unsigned
-    ; sum_fl = (fun v -> [%array1.fold_left.int8_unsigned.fortran (+) 0 v])
-    ; sum_fr = (fun v -> [%array1.fold_right.int8_unsigned.fortran (+) 0 v])
-    ; sum_cl = (fun v -> [%array1.fold_left.int8_unsigned.c (+) 0 v])
-    ; sum_cr = (fun v -> [%array1.fold_right.int8_unsigned.c (+) 0 v])
+    ; sum_fl = (fun v -> [%array1.int8_unsigned.fortran fold_left (+) 0 v])
+    ; sum_fr = (fun v -> [%array1.int8_unsigned.fortran fold_right (+) 0 v])
+    ; sum_cl = (fun v -> [%array1.int8_unsigned.c fold_left (+) 0 v])
+    ; sum_cr = (fun v -> [%array1.int8_unsigned.c fold_right (+) 0 v])
     ; eq = (=)
     };
   per "int16_signed"
     { sum_n = (fun (v : int array) -> Array.fold_left (+) 0 v)
     ; kind  = Int16_signed
-    ; sum_fl = (fun v -> [%array1.fold_left.int16_signed.fortran (+) 0 v])
-    ; sum_fr = (fun v -> [%array1.fold_right.int16_signed.fortran (+) 0 v])
-    ; sum_cl = (fun v -> [%array1.fold_left.int16_signed.c (+) 0 v])
-    ; sum_cr = (fun v -> [%array1.fold_right.int16_signed.c (+) 0 v])
+    ; sum_fl = (fun v -> [%array1.int16_signed.fortran fold_left (+) 0 v])
+    ; sum_fr = (fun v -> [%array1.int16_signed.fortran fold_right (+) 0 v])
+    ; sum_cl = (fun v -> [%array1.int16_signed.c fold_left (+) 0 v])
+    ; sum_cr = (fun v -> [%array1.int16_signed.c fold_right (+) 0 v])
     ; eq = (=)
     };
   per "int16_unsigned"
     { sum_n = (fun (v : int array) -> Array.fold_left (+) 0 v)
     ; kind  = Int16_unsigned
-    ; sum_fl = (fun v -> [%array1.fold_left.int16_unsigned.fortran (+) 0 v])
-    ; sum_fr = (fun v -> [%array1.fold_right.int16_unsigned.fortran (+) 0 v])
-    ; sum_cl = (fun v -> [%array1.fold_left.int16_unsigned.c (+) 0 v])
-    ; sum_cr = (fun v -> [%array1.fold_right.int16_unsigned.c (+) 0 v])
+    ; sum_fl = (fun v -> [%array1.int16_unsigned.fortran fold_left (+) 0 v])
+    ; sum_fr = (fun v -> [%array1.int16_unsigned.fortran fold_right (+) 0 v])
+    ; sum_cl = (fun v -> [%array1.int16_unsigned.c fold_left (+) 0 v])
+    ; sum_cr = (fun v -> [%array1.int16_unsigned.c fold_right (+) 0 v])
     ; eq = (=)
     };
   per "int"
     { sum_n = (fun (v : int array) -> Array.fold_left (+) 0 v)
     ; kind  = Int
-    ; sum_fl = (fun v -> [%array1.fold_left.int.fortran (+) 0 v])
-    ; sum_fr = (fun v -> [%array1.fold_right.int.fortran (+) 0 v])
-    ; sum_cl = (fun v -> [%array1.fold_left.int.c (+) 0 v])
-    ; sum_cr = (fun v -> [%array1.fold_right.int.c (+) 0 v])
+    ; sum_fl = (fun v -> [%array1.int.fortran fold_left (+) 0 v])
+    ; sum_fr = (fun v -> [%array1.int.fortran fold_right (+) 0 v])
+    ; sum_cl = (fun v -> [%array1.int.c fold_left (+) 0 v])
+    ; sum_cr = (fun v -> [%array1.int.c fold_right (+) 0 v])
     ; eq = (=)
     };
   per "int32"
     { sum_n = (fun (v : int32 array) -> Array.fold_left Int32.add 0l v)
     ; kind  = Int32
-    ; sum_fl = (fun v -> [%array1.fold_left.int32.fortran Int32.add 0l v])
-    ; sum_fr = (fun v -> [%array1.fold_right.int32.fortran Int32.add 0l v])
-    ; sum_cl = (fun v -> [%array1.fold_left.int32.c Int32.add 0l v])
-    ; sum_cr = (fun v -> [%array1.fold_right.int32.c Int32.add 0l v])
+    ; sum_fl = (fun v -> [%array1.int32.fortran fold_left Int32.add 0l v])
+    ; sum_fr = (fun v -> [%array1.int32.fortran fold_right Int32.add 0l v])
+    ; sum_cl = (fun v -> [%array1.int32.c fold_left Int32.add 0l v])
+    ; sum_cr = (fun v -> [%array1.int32.c fold_right Int32.add 0l v])
     ; eq = (=)
     };
   per "int64"
     { sum_n = (fun (v : int64 array) -> Array.fold_left Int64.add 0L v)
     ; kind  = Int64
-    ; sum_fl = (fun v -> [%array1.fold_left.int64.fortran Int64.add 0L v])
-    ; sum_fr = (fun v -> [%array1.fold_right.int64.fortran Int64.add 0L v])
-    ; sum_cl = (fun v -> [%array1.fold_left.int64.c Int64.add 0L v])
-    ; sum_cr = (fun v -> [%array1.fold_right.int64.c Int64.add 0L v])
+    ; sum_fl = (fun v -> [%array1.int64.fortran fold_left Int64.add 0L v])
+    ; sum_fr = (fun v -> [%array1.int64.fortran fold_right Int64.add 0L v])
+    ; sum_cl = (fun v -> [%array1.int64.c fold_left Int64.add 0L v])
+    ; sum_cr = (fun v -> [%array1.int64.c fold_right Int64.add 0L v])
     ; eq = (=)
     };
   per "nativeint"
     { sum_n = (fun (v : Nativeint.t array) -> Array.fold_left Nativeint.add 0n v)
     ; kind  = Nativeint
-    ; sum_fl = (fun v -> [%array1.fold_left.nativeint.fortran Nativeint.add 0n v])
-    ; sum_fr = (fun v -> [%array1.fold_right.nativeint.fortran Nativeint.add 0n v])
-    ; sum_cl = (fun v -> [%array1.fold_left.nativeint.c Nativeint.add 0n v])
-    ; sum_cr = (fun v -> [%array1.fold_right.nativeint.c Nativeint.add 0n v])
+    ; sum_fl = (fun v -> [%array1.nativeint.fortran fold_left Nativeint.add 0n v])
+    ; sum_fr = (fun v -> [%array1.nativeint.fortran fold_right Nativeint.add 0n v])
+    ; sum_cl = (fun v -> [%array1.nativeint.c fold_left Nativeint.add 0n v])
+    ; sum_cr = (fun v -> [%array1.nativeint.c fold_right Nativeint.add 0n v])
     ; eq = (=)
     };
   let clor a b = (int_of_char a) lor (int_of_char b) |> Char.chr in
   per "char"
     { sum_n = (fun (v : char array) -> Array.fold_left clor '\000' v)
     ; kind  = Char
-    ; sum_fl = (fun v -> [%array1.fold_left.char.fortran clor '\000' v])
-    ; sum_fr = (fun v -> [%array1.fold_right.char.fortran clor '\000' v])
-    ; sum_cl = (fun v -> [%array1.fold_left.char.c clor '\000' v])
-    ; sum_cr = (fun v -> [%array1.fold_right.char.c clor '\000' v])
+    ; sum_fl = (fun v -> [%array1.char.fortran fold_left clor '\000' v])
+    ; sum_fr = (fun v -> [%array1.char.fortran fold_right clor '\000' v])
+    ; sum_cl = (fun v -> [%array1.char.c fold_left clor '\000' v])
+    ; sum_cr = (fun v -> [%array1.char.c fold_right clor '\000' v])
     ; eq = (=)
     }


### PR DESCRIPTION
This PR fixes #21:

- Moves `fold_left`, `fold_right` and `iter` out of ppx declaration and as function invocation.
- Add labels (`~f` and `~init`) to mirror labeled function invocation.