### PR TITLE
Use core_bench for accuracy.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ fold_ppx:
 	ocamlbuild -use-ocamlfind -pkgs compiler-libs.common -I +compiler-libs -I src/fold_ppx fold_ppx.byte
 
 fold_ppx_test: fold_ppx bau
-	ocamlbuild -use-ocamlfind -pkgs bigarray -tags "ppx(src/fold_ppx/fold_ppx.byte)" -I src/lib -I src/fold_ppx -I src/scripts -cflag -dsource fold_ppx_test.native
+	ocamlbuild -use-ocamlfind -pkgs core_bench,core,bigarray -tag thread -tags "ppx(src/fold_ppx/fold_ppx.byte)" -I src/lib -I src/fold_ppx -I src/scripts -cflag -dsource fold_ppx_test.native
 
 fold_ppx_prof: fold_ppx bau
 	ocamlbuild -use-ocamlfind -pkgs bigarray -tags "ppx(src/fold_ppx/fold_ppx.byte)" -I src/lib -I src/fold_ppx -I src/scripts -cflag -dsource fold_ppx_prof.native

--- a/src/scripts/fold_ppx_test.ml
+++ b/src/scripts/fold_ppx_test.ml
@@ -1,10 +1,11 @@
 open Bigarrayo
 
-let time s f =
+(*let time s f =
   let n = Sys.time () in
   let r = f () in
   Printf.printf "%-30s:%f\n" s (Sys.time () -. n);
   r
+  *)
 
 let generate kind n =
   let gen  = Generators.random kind in
@@ -35,18 +36,17 @@ let eq_array_c arr1 arr2 =
       && equal_floats v.Complex.im arr2.(i).Complex.im, i + 1) (true, 0) arr1
   |> fst
 
-
 type ('a, 'b) pt =
-  { sum_n : 'a array -> 'a
-  ; kind  : ('a, 'b) kind
+  { kind  : ('a, 'b) kind
+  ; sum_n : 'a array -> 'a
   ; sum_fl : ('a, 'b, fortran_layout) Array1.t -> 'a
   ; sum_fr : ('a, 'b, fortran_layout) Array1.t -> 'a
   ; sum_cl : ('a, 'b, c_layout) Array1.t -> 'a
   ; sum_cr : ('a, 'b, c_layout) Array1.t -> 'a
-  ; eq     : 'a array -> 'a array -> bool
   }
 
 let () =
+  let open Core_bench.Std in
   let samples, n =
     if Array.length Sys.argv < 3 then
       10000, 40
@@ -55,138 +55,123 @@ let () =
       , int_of_string Sys.argv.(2)
   in
   Printf.printf "%d samples of %d \n" samples n;
-  let per : type a b. string -> (a, b) pt -> unit =
+  let per : type a b. string -> (a, b) pt -> Bench.Test.t =
     fun ks pt ->
-      Printf.printf "over ---- %s ----\n" ks;
-      Gc.full_major ();
       let data = Array.init samples (fun _ -> generate pt.kind n) in
-      let test name op = time name (fun () -> Array.map op data) in
-      let native  = test "native" (fun (n,_,_) -> pt.sum_n n) in
-      let bgfolfl = test "array1 left fortran" (fun (_,f,_) -> pt.sum_fl f) in
-      let bgfolfr = test "array1 right fortran" (fun (_,f,_) -> pt.sum_fr f) in
-      let bgfolcl = test "array1 left c"       (fun (_,_,c) -> pt.sum_cl c) in
-      let bgfolcr = test "array1 right c"       (fun (_,_,c) -> pt.sum_cr c) in
-      Printf.printf "equal %b\n"
-        ((pt.eq native bgfolfl)
-        && (pt.eq bgfolfl bgfolfr)
-        && (pt.eq bgfolfr bgfolcl)
-        && (pt.eq bgfolcl bgfolcr))
+      let test name op =
+        Bench.Test.create ~name (fun () -> Array.map op data)
+      in
+      [ test "native"               (fun (n,_,_) -> pt.sum_n n)
+      ; test "array1 left fortran"  (fun (_,f,_) -> pt.sum_fl f)
+      ; test "array1 right fortran" (fun (_,f,_) -> pt.sum_fr f)
+      ; test "array1 left c"        (fun (_,_,c) -> pt.sum_cl c)
+      ; test "array1 right c"       (fun (_,_,c) -> pt.sum_cr c)
+      ] |> Bench.Test.create_group ~name:ks
   in
-  per "float32"
-    { sum_n = (fun (v : float array) -> Array.fold_left (+.) 0. v)
-    ; kind  = Float32
-    ; sum_fl = (fun v -> [%array1.float32.fortran fold_left (+.) 0. v])
-    ; sum_fr = (fun v -> [%array1.float32.fortran fold_right (+.) 0. v])
-    ; sum_cl = (fun v -> [%array1.float32.c fold_left (+.) 0. v])
-    ; sum_cr = (fun v -> [%array1.float32.c fold_right (+.) 0. v])
-    ; eq = eq_array
-    };
-  per "float64"
-    { sum_n = (fun (v : float array) -> Array.fold_left (+.) 0. v)
-    ; kind  = Float64
-    ; sum_fl = (fun v -> [%array1.float64.fortran fold_left (+.) 0. v])
-    ; sum_fr = (fun v -> [%array1.float64.fortran fold_right (+.) 0. v])
-    ; sum_cl = (fun v -> [%array1.float64.c fold_left (+.) 0. v])
-    ; sum_cr = (fun v -> [%array1.float64.c fold_right (+.) 0. v])
-    ; eq = eq_array
-    };
-  per "complex32"
-    { sum_n = (fun v  -> Array.fold_left Complex.add Complex.zero v)
-    ; kind  = Complex32
-    ; sum_fl = (fun v -> [%array1.complex32.fortran fold_left Complex.add Complex.zero v])
-    ; sum_fr = (fun v -> [%array1.complex32.fortran fold_right Complex.add Complex.zero v])
-    ; sum_cl = (fun v -> [%array1.complex32.c fold_left Complex.add Complex.zero v])
-    ; sum_cr = (fun v -> [%array1.complex32.c fold_right Complex.add Complex.zero v])
-    ; eq = eq_array_c
-    };
-  per "complex64"
-    { sum_n = (fun v  -> Array.fold_left Complex.add Complex.zero v)
-    ; kind  = Complex64
-    ; sum_fl = (fun v -> [%array1.complex64.fortran fold_left Complex.add Complex.zero v])
-    ; sum_fr = (fun v -> [%array1.complex64.fortran fold_right Complex.add Complex.zero v])
-    ; sum_cl = (fun v -> [%array1.complex64.c fold_left Complex.add Complex.zero v])
-    ; sum_cr = (fun v -> [%array1.complex64.c fold_right Complex.add Complex.zero v])
-    ; eq = eq_array_c
-    };
-  per "int8_signed"
-    { sum_n = (fun (v : int array) -> Array.fold_left (+) 0 v)
-    ; kind  = Int8_signed
-    ; sum_fl = (fun v -> [%array1.int8_signed.fortran fold_left (+) 0 v])
-    ; sum_fr = (fun v -> [%array1.int8_signed.fortran fold_right (+) 0 v])
-    ; sum_cl = (fun v -> [%array1.int8_signed.c fold_left (+) 0 v])
-    ; sum_cr = (fun v -> [%array1.int8_signed.c fold_right (+) 0 v])
-    ; eq = (=)
-    };
-  per "int8_unsigned"
-    { sum_n = (fun (v : int array) -> Array.fold_left (+) 0 v)
-    ; kind  = Int8_unsigned
-    ; sum_fl = (fun v -> [%array1.int8_unsigned.fortran fold_left (+) 0 v])
-    ; sum_fr = (fun v -> [%array1.int8_unsigned.fortran fold_right (+) 0 v])
-    ; sum_cl = (fun v -> [%array1.int8_unsigned.c fold_left (+) 0 v])
-    ; sum_cr = (fun v -> [%array1.int8_unsigned.c fold_right (+) 0 v])
-    ; eq = (=)
-    };
-  per "int16_signed"
-    { sum_n = (fun (v : int array) -> Array.fold_left (+) 0 v)
-    ; kind  = Int16_signed
-    ; sum_fl = (fun v -> [%array1.int16_signed.fortran fold_left (+) 0 v])
-    ; sum_fr = (fun v -> [%array1.int16_signed.fortran fold_right (+) 0 v])
-    ; sum_cl = (fun v -> [%array1.int16_signed.c fold_left (+) 0 v])
-    ; sum_cr = (fun v -> [%array1.int16_signed.c fold_right (+) 0 v])
-    ; eq = (=)
-    };
-  per "int16_unsigned"
-    { sum_n = (fun (v : int array) -> Array.fold_left (+) 0 v)
-    ; kind  = Int16_unsigned
-    ; sum_fl = (fun v -> [%array1.int16_unsigned.fortran fold_left (+) 0 v])
-    ; sum_fr = (fun v -> [%array1.int16_unsigned.fortran fold_right (+) 0 v])
-    ; sum_cl = (fun v -> [%array1.int16_unsigned.c fold_left (+) 0 v])
-    ; sum_cr = (fun v -> [%array1.int16_unsigned.c fold_right (+) 0 v])
-    ; eq = (=)
-    };
-  per "int"
-    { sum_n = (fun (v : int array) -> Array.fold_left (+) 0 v)
-    ; kind  = Int
-    ; sum_fl = (fun v -> [%array1.int.fortran fold_left (+) 0 v])
-    ; sum_fr = (fun v -> [%array1.int.fortran fold_right (+) 0 v])
-    ; sum_cl = (fun v -> [%array1.int.c fold_left (+) 0 v])
-    ; sum_cr = (fun v -> [%array1.int.c fold_right (+) 0 v])
-    ; eq = (=)
-    };
-  per "int32"
-    { sum_n = (fun (v : int32 array) -> Array.fold_left Int32.add 0l v)
-    ; kind  = Int32
-    ; sum_fl = (fun v -> [%array1.int32.fortran fold_left Int32.add 0l v])
-    ; sum_fr = (fun v -> [%array1.int32.fortran fold_right Int32.add 0l v])
-    ; sum_cl = (fun v -> [%array1.int32.c fold_left Int32.add 0l v])
-    ; sum_cr = (fun v -> [%array1.int32.c fold_right Int32.add 0l v])
-    ; eq = (=)
-    };
-  per "int64"
-    { sum_n = (fun (v : int64 array) -> Array.fold_left Int64.add 0L v)
-    ; kind  = Int64
-    ; sum_fl = (fun v -> [%array1.int64.fortran fold_left Int64.add 0L v])
-    ; sum_fr = (fun v -> [%array1.int64.fortran fold_right Int64.add 0L v])
-    ; sum_cl = (fun v -> [%array1.int64.c fold_left Int64.add 0L v])
-    ; sum_cr = (fun v -> [%array1.int64.c fold_right Int64.add 0L v])
-    ; eq = (=)
-    };
-  per "nativeint"
-    { sum_n = (fun (v : Nativeint.t array) -> Array.fold_left Nativeint.add 0n v)
-    ; kind  = Nativeint
-    ; sum_fl = (fun v -> [%array1.nativeint.fortran fold_left Nativeint.add 0n v])
-    ; sum_fr = (fun v -> [%array1.nativeint.fortran fold_right Nativeint.add 0n v])
-    ; sum_cl = (fun v -> [%array1.nativeint.c fold_left Nativeint.add 0n v])
-    ; sum_cr = (fun v -> [%array1.nativeint.c fold_right Nativeint.add 0n v])
-    ; eq = (=)
-    };
   let clor a b = (int_of_char a) lor (int_of_char b) |> Char.chr in
-  per "char"
-    { sum_n = (fun (v : char array) -> Array.fold_left clor '\000' v)
-    ; kind  = Char
-    ; sum_fl = (fun v -> [%array1.char.fortran fold_left clor '\000' v])
-    ; sum_fr = (fun v -> [%array1.char.fortran fold_right clor '\000' v])
-    ; sum_cl = (fun v -> [%array1.char.c fold_left clor '\000' v])
-    ; sum_cr = (fun v -> [%array1.char.c fold_right clor '\000' v])
-    ; eq = (=)
-    }
+  [ per "float32"
+      { kind  = Float32
+      ; sum_n = (fun (v : float array) -> Array.fold_left (+.) 0. v)
+      ; sum_fl = (fun v -> [%array1.float32.fortran fold_left (+.) 0. v])
+      ; sum_fr = (fun v -> [%array1.float32.fortran fold_right (+.) 0. v])
+      ; sum_cl = (fun v -> [%array1.float32.c fold_left (+.) 0. v])
+      ; sum_cr = (fun v -> [%array1.float32.c fold_right (+.) 0. v])
+      }
+  ; per "float64"
+      { kind  = Float64
+      ; sum_n = (fun (v : float array) -> Array.fold_left (+.) 0. v)
+      ; sum_fl = (fun v -> [%array1.float64.fortran fold_left (+.) 0. v])
+      ; sum_fr = (fun v -> [%array1.float64.fortran fold_right (+.) 0. v])
+      ; sum_cl = (fun v -> [%array1.float64.c fold_left (+.) 0. v])
+      ; sum_cr = (fun v -> [%array1.float64.c fold_right (+.) 0. v])
+      }
+  ; per "complex32"
+      { kind  = Complex32
+      ; sum_n = (fun v  -> Array.fold_left Complex.add Complex.zero v)
+      ; sum_fl = (fun v -> [%array1.complex32.fortran fold_left Complex.add Complex.zero v])
+      ; sum_fr = (fun v -> [%array1.complex32.fortran fold_right Complex.add Complex.zero v])
+      ; sum_cl = (fun v -> [%array1.complex32.c fold_left Complex.add Complex.zero v])
+      ; sum_cr = (fun v -> [%array1.complex32.c fold_right Complex.add Complex.zero v])
+      }
+  ; per "complex64"
+      { kind  = Complex64
+      ; sum_n = (fun v  -> Array.fold_left Complex.add Complex.zero v)
+      ; sum_fl = (fun v -> [%array1.complex64.fortran fold_left Complex.add Complex.zero v])
+      ; sum_fr = (fun v -> [%array1.complex64.fortran fold_right Complex.add Complex.zero v])
+      ; sum_cl = (fun v -> [%array1.complex64.c fold_left Complex.add Complex.zero v])
+      ; sum_cr = (fun v -> [%array1.complex64.c fold_right Complex.add Complex.zero v])
+      }
+  ; per "int8_signed"
+      { kind  = Int8_signed
+      ; sum_n = (fun (v : int array) -> Array.fold_left (+) 0 v)
+      ; sum_fl = (fun v -> [%array1.int8_signed.fortran fold_left (+) 0 v])
+      ; sum_fr = (fun v -> [%array1.int8_signed.fortran fold_right (+) 0 v])
+      ; sum_cl = (fun v -> [%array1.int8_signed.c fold_left (+) 0 v])
+      ; sum_cr = (fun v -> [%array1.int8_signed.c fold_right (+) 0 v])
+      }
+  ; per "int8_unsigned"
+      { kind  = Int8_unsigned
+      ; sum_n = (fun (v : int array) -> Array.fold_left (+) 0 v)
+      ; sum_fl = (fun v -> [%array1.int8_unsigned.fortran fold_left (+) 0 v])
+      ; sum_fr = (fun v -> [%array1.int8_unsigned.fortran fold_right (+) 0 v])
+      ; sum_cl = (fun v -> [%array1.int8_unsigned.c fold_left (+) 0 v])
+      ; sum_cr = (fun v -> [%array1.int8_unsigned.c fold_right (+) 0 v])
+      }
+  ; per "int16_signed"
+      { kind  = Int16_signed
+      ; sum_n = (fun (v : int array) -> Array.fold_left (+) 0 v)
+      ; sum_fl = (fun v -> [%array1.int16_signed.fortran fold_left (+) 0 v])
+      ; sum_fr = (fun v -> [%array1.int16_signed.fortran fold_right (+) 0 v])
+      ; sum_cl = (fun v -> [%array1.int16_signed.c fold_left (+) 0 v])
+      ; sum_cr = (fun v -> [%array1.int16_signed.c fold_right (+) 0 v])
+      }
+  ; per "int16_unsigned"
+      { kind  = Int16_unsigned
+      ; sum_n = (fun (v : int array) -> Array.fold_left (+) 0 v)
+      ; sum_fl = (fun v -> [%array1.int16_unsigned.fortran fold_left (+) 0 v])
+      ; sum_fr = (fun v -> [%array1.int16_unsigned.fortran fold_right (+) 0 v])
+      ; sum_cl = (fun v -> [%array1.int16_unsigned.c fold_left (+) 0 v])
+      ; sum_cr = (fun v -> [%array1.int16_unsigned.c fold_right (+) 0 v])
+      }
+  ; per "int"
+      { kind  = Int
+      ; sum_n = (fun (v : int array) -> Array.fold_left (+) 0 v)
+      ; sum_fl = (fun v -> [%array1.int.fortran fold_left (+) 0 v])
+      ; sum_fr = (fun v -> [%array1.int.fortran fold_right (+) 0 v])
+      ; sum_cl = (fun v -> [%array1.int.c fold_left (+) 0 v])
+      ; sum_cr = (fun v -> [%array1.int.c fold_right (+) 0 v])
+      }
+  ; per "int32"
+      { kind  = Int32
+      ; sum_n = (fun (v : int32 array) -> Array.fold_left Int32.add 0l v)
+      ; sum_fl = (fun v -> [%array1.int32.fortran fold_left Int32.add 0l v])
+      ; sum_fr = (fun v -> [%array1.int32.fortran fold_right Int32.add 0l v])
+      ; sum_cl = (fun v -> [%array1.int32.c fold_left Int32.add 0l v])
+      ; sum_cr = (fun v -> [%array1.int32.c fold_right Int32.add 0l v])
+      }
+  ; per "int64"
+      { kind  = Int64
+      ; sum_n = (fun (v : int64 array) -> Array.fold_left Int64.add 0L v)
+      ; sum_fl = (fun v -> [%array1.int64.fortran fold_left Int64.add 0L v])
+      ; sum_fr = (fun v -> [%array1.int64.fortran fold_right Int64.add 0L v])
+      ; sum_cl = (fun v -> [%array1.int64.c fold_left Int64.add 0L v])
+      ; sum_cr = (fun v -> [%array1.int64.c fold_right Int64.add 0L v])
+      }
+  ; per "nativeint"
+      { kind  = Nativeint
+      ; sum_n = (fun (v : Nativeint.t array) -> Array.fold_left Nativeint.add 0n v)
+      ; sum_fl = (fun v -> [%array1.nativeint.fortran fold_left Nativeint.add 0n v])
+      ; sum_fr = (fun v -> [%array1.nativeint.fortran fold_right Nativeint.add 0n v])
+      ; sum_cl = (fun v -> [%array1.nativeint.c fold_left Nativeint.add 0n v])
+      ; sum_cr = (fun v -> [%array1.nativeint.c fold_right Nativeint.add 0n v])
+      }
+  ; per "char"
+      { kind  = Char
+      ; sum_n = (fun (v : char array) -> Array.fold_left clor '\000' v)
+      ; sum_fl = (fun v -> [%array1.char.fortran fold_left clor '\000' v])
+      ; sum_fr = (fun v -> [%array1.char.fortran fold_right clor '\000' v])
+      ; sum_cl = (fun v -> [%array1.char.c fold_left clor '\000' v])
+      ; sum_cr = (fun v -> [%array1.char.c fold_right clor '\000' v])
+      }]
+  |> Bench.make_command
+  |> Core.Command.run


### PR DESCRIPTION
Sample run:
```
┌─────────────────────────────────────┬────────────┬────────────┬──────────┬────────────┬────────────┐
│ Name                                │   Time/Run │    mWd/Run │ mjWd/Run │   Prom/Run │ Percentage │
├─────────────────────────────────────┼────────────┼────────────┼──────────┼────────────┼────────────┤
│ float32/native                      │ 1_999.14us │ 1_600.02kw │  10.02kw │     18.02w │     39.90% │
│ float32/array1 left fortran         │   876.52us │    20.00kw │  10.00kw │            │     17.49% │
│ float32/array1 right fortran        │   953.08us │    20.00kw │  10.00kw │            │     19.02% │
│ float32/array1 left c               │   779.16us │    20.00kw │  10.00kw │            │     15.55% │
│ float32/array1 right c              │   933.25us │    20.00kw │  10.00kw │            │     18.62% │
│ float64/native                      │ 1_991.88us │ 1_600.02kw │  10.02kw │     18.02w │     39.75% │
│ float64/array1 left fortran         │ 1_037.60us │    20.00kw │  10.00kw │            │     20.71% │
│ float64/array1 right fortran        │ 1_126.08us │    20.00kw │  10.00kw │            │     22.47% │
│ float64/array1 left c               │ 1_030.65us │    20.00kw │  10.00kw │            │     20.57% │
│ float64/array1 right c              │ 1_218.40us │    20.00kw │  10.00kw │            │     24.31% │
│ complex32/native                    │ 3_872.93us │ 1_200.03kw │  40.01kw │ 30_010.53w │     77.29% │
│ complex32/array1 left fortran       │ 3_858.26us │ 2_400.05kw │  40.05kw │ 30_048.49w │     77.00% │
│ complex32/array1 right fortran      │ 3_918.00us │ 2_400.05kw │  40.05kw │ 30_048.48w │     78.19% │
│ complex32/array1 left c             │ 3_674.44us │ 2_400.05kw │  40.05kw │ 30_048.44w │     73.33% │
│ complex32/array1 right c            │ 3_858.90us │ 2_400.05kw │  40.05kw │ 30_048.48w │     77.01% │
│ complex64/native                    │ 3_451.12us │ 1_200.03kw │  40.01kw │ 30_009.79w │     68.87% │
│ complex64/array1 left fortran       │ 3_849.47us │ 2_400.05kw │  40.05kw │ 30_048.49w │     76.82% │
│ complex64/array1 right fortran      │ 4_592.63us │ 2_400.05kw │  40.05kw │ 30_048.61w │     91.65% │
│ complex64/array1 left c             │ 3_861.70us │ 2_400.05kw │  40.05kw │ 30_048.51w │     77.07% │
│ complex64/array1 right c            │ 5_010.95us │ 2_400.05kw │  40.05kw │ 30_048.69w │    100.00% │
│ int8_signed/native                  │ 1_739.42us │            │  10.00kw │      0.16w │     34.71% │
│ int8_signed/array1 left fortran     │   674.99us │            │  10.00kw │            │     13.47% │
│ int8_signed/array1 right fortran    │   890.81us │            │  10.00kw │            │     17.78% │
│ int8_signed/array1 left c           │   804.88us │            │  10.00kw │            │     16.06% │
│ int8_signed/array1 right c          │   806.57us │            │  10.00kw │            │     16.10% │
│ int8_unsigned/native                │ 1_616.54us │            │  10.00kw │      0.15w │     32.26% │
│ int8_unsigned/array1 left fortran   │   710.67us │            │  10.00kw │            │     14.18% │
│ int8_unsigned/array1 right fortran  │   826.94us │            │  10.00kw │            │     16.50% │
│ int8_unsigned/array1 left c         │   778.15us │            │  10.00kw │            │     15.53% │
│ int8_unsigned/array1 right c        │   805.27us │            │  10.00kw │            │     16.07% │
│ int16_signed/native                 │ 1_483.11us │            │  10.00kw │      0.15w │     29.60% │
│ int16_signed/array1 left fortran    │   787.87us │            │  10.00kw │            │     15.72% │
│ int16_signed/array1 right fortran   │   883.67us │            │  10.00kw │            │     17.63% │
│ int16_signed/array1 left c          │   743.67us │            │  10.00kw │            │     14.84% │
│ int16_signed/array1 right c         │ 1_031.47us │            │  10.00kw │            │     20.58% │
│ int16_unsigned/native               │ 1_513.70us │            │  10.00kw │      0.14w │     30.21% │
│ int16_unsigned/array1 left fortran  │   741.19us │            │  10.00kw │            │     14.79% │
│ int16_unsigned/array1 right fortran │   762.19us │            │  10.00kw │            │     15.21% │
│ int16_unsigned/array1 left c        │   699.53us │            │  10.00kw │            │     13.96% │
│ int16_unsigned/array1 right c       │   996.12us │            │  10.00kw │            │     19.88% │
│ int/native                          │ 1_522.37us │            │  10.00kw │      0.14w │     30.38% │
│ int/array1 left fortran             │ 1_281.18us │            │  10.00kw │      0.13w │     25.57% │
│ int/array1 right fortran            │ 1_221.41us │            │  10.00kw │      0.12w │     24.37% │
│ int/array1 left c                   │   999.49us │            │  10.00kw │            │     19.95% │
│ int/array1 right c                  │ 1_288.95us │            │  10.00kw │      0.12w │     25.72% │
│ int32/native                        │ 3_299.04us │ 1_200.03kw │  40.01kw │ 30_009.65w │     65.84% │
│ int32/array1 left fortran           │ 2_028.59us │    30.00kw │  40.02kw │ 30_017.82w │     40.48% │
│ int32/array1 right fortran          │ 2_118.84us │    30.00kw │  40.02kw │ 30_018.55w │     42.28% │
│ int32/array1 left c                 │ 2_021.83us │    30.00kw │  40.02kw │ 30_017.82w │     40.35% │
│ int32/array1 right c                │ 2_239.87us │    30.00kw │  40.02kw │ 30_019.74w │     44.70% │
│ int64/native                        │ 3_444.79us │ 1_200.03kw │  40.01kw │ 30_009.60w │     68.75% │
│ int64/array1 left fortran           │ 2_081.95us │    30.00kw │  40.02kw │ 30_016.81w │     41.55% │
│ int64/array1 right fortran          │ 2_136.97us │    30.00kw │  40.02kw │ 30_020.59w │     42.65% │
│ int64/array1 left c                 │ 1_874.44us │    30.00kw │  40.02kw │ 30_016.18w │     37.41% │
│ int64/array1 right c                │ 1_894.82us │    30.00kw │  40.02kw │ 30_016.49w │     37.81% │
│ nativeint/native                    │ 3_281.88us │ 1_200.03kw │  40.01kw │ 30_009.57w │     65.49% │
│ nativeint/array1 left fortran       │ 1_874.75us │    30.00kw │  40.02kw │ 30_016.49w │     37.41% │
│ nativeint/array1 right fortran      │ 2_088.97us │    30.00kw │  40.02kw │ 30_018.18w │     41.69% │
│ nativeint/array1 left c             │ 1_850.77us │    30.00kw │  40.02kw │ 30_016.18w │     36.93% │
│ nativeint/array1 right c            │ 2_002.31us │    30.00kw │  40.02kw │ 30_017.47w │     39.96% │
│ char/native                         │ 1_722.45us │            │  10.00kw │      0.18w │     34.37% │
│ char/array1 left fortran            │ 1_403.30us │            │  10.00kw │      0.14w │     28.00% │
│ char/array1 right fortran           │ 1_487.44us │            │  10.00kw │      0.15w │     29.68% │
│ char/array1 left c                  │ 1_170.75us │            │  10.00kw │      0.13w │     23.36% │
│ char/array1 right c                 │ 1_532.50us │            │  10.00kw │      0.17w │     30.58% │
└─────────────────────────────────────┴────────────┴────────────┴──────────┴────────────┴────────────┘
```